### PR TITLE
feature_thelia_25_561669_front_home

### DIFF
--- a/Config/config.xml
+++ b/Config/config.xml
@@ -18,7 +18,10 @@
             <tag name="hook.event_listener" event="account.additional" type="front" method="onAccountAdditional"/>
             <tag name="hook.event_listener" event="main.stylesheet" type="front" method="onMainStylesheet"/>
             <tag name="hook.event_listener" event="main.javascript-initialization" type="front" method="onMainJavascriptInitialization"/>
-            <argument type="service" id="request" />
+            <argument type="service" id="thelia.parser" />
+            <argument type="service" id="thelia.parser.asset.resolver" />
+            <argument type="service" id="event_dispatcher" />
+            <argument type="service" id="request_stack" />
         </hook>
         <hook id="hybridauth.back.hook" class="TheliaHybridAuth\Hook\BackHook" scope="request">
             <tag name="hook.event_listener" event="module.configuration" type="back" method="onModuleConfiguration"/>

--- a/Form/Register.php
+++ b/Form/Register.php
@@ -51,9 +51,7 @@ class Register extends CustomerCreateForm
                 'constraints' => [
                     new Constraints\NotBlank(),
                     new Constraints\Length(['min' => ConfigQuery::read('password.length', 4)]),
-                    new Constraints\Callback(['methods' => [
-                        [$this, 'verifyPasswordField'],
-                    ]]),
+                    new Constraints\Callback(['callback' => [$this, 'verifyPasswordField']]),
                 ],
                 'label' => Translator::getInstance()->trans(
                     'Password confirmation',


### PR DESCRIPTION
### Type de MR
FEATURE

### Ticket
https://www.demandedesupport.com/issues/561669

### Impact
utilisateur|consommateur|interne

### Phrase de description dans le mail de livraison
`Ajustement de l'affichage de la page d'accueil du front` 

### Procédure de tests
+ Activer des catégories et des produits visible en front
+ Se rendre sur la page d'accueil du front
+ La page d'accueil doit s'afficher sans erreur 
+ Vous devez voir les produits mis en avant (coup de coeur, ...)

### Lié aux MR ::
+ https://git.centraldev.api-and-you.com/apymybox/apymybox/-/merge_requests/2660
+ https://git.centraldev.api-and-you.com/apymybox/apythemev3/-/merge_requests/711
+ https://git.centraldev.api-and-you.com/apymybox/ApyUtilities/-/merge_requests/376
+ https://git.centraldev.api-and-you.com/apymybox/apystoreconfiguration/-/merge_requests/157
+ https://github.com/lesateliersapicius/TheliaHybridAuth/pull/11

/label ~"Thelia 2.5" 
