### PR TITLE
fix_state_1122155

### DIFF
--- a/templates/frontOffice/default/register-hybrid-auth.html
+++ b/templates/frontOffice/default/register-hybrid-auth.html
@@ -309,6 +309,11 @@
     </article>
 
   </div><!-- /.layout -->
+
+  {***** tpl créant les options pour les select des états *****}
+  <script data-template="option-choose-state" type="text/template">
+    <option value="">{intl l="apythemev3.fo.state"}&nbsp;*</option>
+  </script>
 {/block}
 
 


### PR DESCRIPTION
Fix

Ticket: https://www.demandedesupport.com/issues/1122155

Test:
J'ai patché directement sur la prod https://restaurantlesjardiniers.secretbox.fr

Explication:
Il y avait un problème lors de la connexion via google le champ État s'affichait alors qu'il ne devait pas s'afficher pour la france.
Maintenant tout fonctionne bien si on sélectionne les états unis on a bien la possibilité de sélectionner l'état
